### PR TITLE
feat: allow themes from User Settings to be used

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,9 @@ Themes can set alternative background for even rows (`alternate-background-color
 Theme now pure QSS, which allow any customisations without changing plugin code.  
 CSS syntax with restricted properties remains only for `quicksearch` styles as they hardcoded at fman.
 
+Plugin also pickup all `.qss` files from `User/Settings` directory.  
+User ones has priority in case of name conflict with predefined themes.
+
 Install with [fman's built-in command for installing plugins](https://fman.io/docs/installing-plugins).
 
 ### Usage

--- a/alternative_colors/__init__.py
+++ b/alternative_colors/__init__.py
@@ -8,7 +8,7 @@ from fman.impl.util.css import parse_css
 
 delayed_init_started = False
 plugin_path = Path(__file__).parent.parent
-plugin_path_user = Path(DATA_DIRECTORY) / 'Plugins' / 'User' / 'Settings'
+settings_path = Path(DATA_DIRECTORY) / 'Plugins' / 'User' / 'Settings'
 settings_file = 'alternative_colors.json'
 current_theme = None
 
@@ -45,53 +45,41 @@ def unload_qss(qss_filename):
     theme._update_app()
 
 
+def get_theme_filename(name):
+    filename = Path(settings_path) / '{}.qss'.format(current_theme)
+    if filename.exists():
+        return filename
+    return Path(plugin_path) / '{}.qss'.format(current_theme)
+
+
 def activate_theme(name, save=True):
     global current_theme
     theme = _get_app_ctxt().theme
     theme._updates_enabled = False
     if current_theme:  # undo previous theme
-        old_filename = Path(plugin_path_user) / '{}.qss'.format(current_theme)
-        if not Path(old_filename).exists():
-            old_filename = Path(plugin_path) / '{}.qss'.format(current_theme)
-        unload_qss(old_filename)
-    filename = Path(plugin_path_user) / '{}.qss'.format(name)
-    if not Path(filename).exists():
-        filename = Path(plugin_path) / '{}.qss'.format(name)
+        unload_qss(get_theme_filename(current_theme))
     current_theme = name
-    load_qss(filename)
+    load_qss(get_theme_filename(name))
     theme.enable_updates()
     if save:
         save_json(settings_file, {'name': name})
 
 
 # add commands to change themes (user themes override plugin defaults)
-plugin_path_user_theme = Path(plugin_path_user).glob('*.qss')
-user_theme_count = 0
-user_theme_file = []
-for i, filename in enumerate(plugin_path_user_theme, start=1):
-    user_theme_count += 1
-    user_theme_file.append(filename.stem)
+themes = {}
+for filename in Path(plugin_path).glob('*.qss'):
+    themes[filename.stem] = filename
+for filename in Path(settings_path).glob('*.qss'):
+    themes[filename.stem] = filename
+for i, name in enumerate(themes.keys(), start=1):
+    filename = themes[name]
     class_name = 'AlternativeColorTheme{}'.format(i)
     globals()[class_name] = type(
         class_name,
         (ApplicationCommand,),
         {
-            'name': filename.stem,
-            'aliases': ('Activate theme "{}"'.format(filename.stem),),
-            '__call__': lambda self: activate_theme(self.name),
-        },
-    )
-plugin_path_theme = Path(plugin_path).glob('*.qss')
-for i, filename in enumerate(plugin_path_theme, start=user_theme_count+1):
-    if filename.stem in user_theme_file:
-        continue
-    class_name = 'AlternativeColorTheme{}'.format(i)
-    globals()[class_name] = type(
-        class_name,
-        (ApplicationCommand,),
-        {
-            'name': filename.stem,
-            'aliases': ('Activate theme "{}"'.format(filename.stem),),
+            'name': name,
+            'aliases': ('Activate theme "{}"'.format(name),),
             '__call__': lambda self: activate_theme(self.name),
         },
     )


### PR DESCRIPTION
Since this is the proper location for user themes (they also don't disappear on the plugin installation/uninstallation)

User themes have priority over and replace the default themes with the same name

