### PR TITLE
Windows Filter Bar Bug (cut off text)

### DIFF
--- a/Material Dark Alt.qss
+++ b/Material Dark Alt.qss
@@ -82,14 +82,16 @@ Overlay {
     border: 1px solid #6272a4;
 }
 
+/* When you type to filter files in any Directory */
 FilterBar {
     background-color: #282a36;
     border: 1px solid #EA80FC;
-
 }
+
 FilterBar QLineEdit{
     color:#cd950c;
-    font-size: 18pt;
+    /* font-size: 18pt; If you need a bigger filter bar enable
+    Removed Due to Windows Bug */
 }
 
 NonexistentShortcutDialog QRadioButton {

--- a/Material Dark.qss
+++ b/Material Dark.qss
@@ -83,14 +83,16 @@ Overlay {
     border: 1px solid #6272a4;
 }
 
+/* When you type to filter files in any Directory */
 FilterBar {
     background-color: #282a36;
     border: 1px solid #EA80FC;
-
 }
+
 FilterBar QLineEdit{
     color:#cd950c;
-    font-size: 18pt;
+    /* font-size: 18pt; If you need a bigger filter bar enable
+    Removed Due to Windows Bug */
 }
 
 NonexistentShortcutDialog QRadioButton {


### PR DESCRIPTION
In windows the filter bar text size was a too big to fit.